### PR TITLE
Deploy The Portfolio to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 - Html
 - Css
 - Git and Github
-- Deployed on gitHub Pages
 
 
 ## Live Demo (if available)
@@ -60,5 +59,3 @@ Give a ⭐️ if you like this project!
 ## 📝 License
 
 This project is [MIT](./MIT.MD) licensed.
-
-_NOTE: we recommend using the [MIT license](https://choosealicense.com/licenses/mit/) - you can set it up quickly by [using templates available on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). You can also use [any other license](https://choosealicense.com/licenses/) if you wish._


### PR DESCRIPTION
### Deploy The Portfolio to GitHub Pages:
1. Deployed the portfolio project on GitHub pages.
2. Updated the Readme file to include link to the portfolio on GitHub page.
3. Enabled HTTPS protocol on accessing the portfolio on the GitHub pages.